### PR TITLE
fix(frontend): add REACT_APP_WS_URL to environment variables

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,3 @@
 REACT_APP_BACKEND_URL=https://2a77fa17-19bc-4315-80dc-d724ac585516.preview.emergentagent.com
+REACT_APP_WS_URL=wss://2a77fa17-19bc-4315-80dc-d724ac585516.preview.emergentagent.com/ws/
 WDS_SOCKET_PORT=443


### PR DESCRIPTION
This commit adds the `REACT_APP_WS_URL` environment variable to the `frontend/.env` file. This variable is necessary for the frontend to connect to the WebSocket server for the live chat feature.

The value is set to the appropriate WebSocket URL for the Render deployment.