### PR TITLE
fix(chat): fix user status display and update logic

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -183,6 +183,17 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
                     else:
                         logging.warning(f"Invalid status update from {user_id}: {new_status}")
 
+                elif message_data["type"] == "get_all_statuses":
+                    all_statuses = {uid: manager.user_status.get(uid, "offline") for uid in manager.user_status}
+                    for uid in manager.active_connections:
+                        if uid not in all_statuses or all_statuses[uid] != "busy":
+                            all_statuses[uid] = "online"
+
+                    await manager.send_personal_message(
+                        json.dumps({"type": "all_statuses", "statuses": all_statuses}),
+                        user_id
+                    )
+
 
             except json.JSONDecodeError:
                 logging.error(f"Failed to decode JSON from {user_id}: {data}")


### PR DESCRIPTION
This commit fixes the issue where your status was defaulting to "Offline" after logging in.

The following changes were made:

- The frontend now optimistically sets your own status to "online" when the WebSocket connects.
- The frontend sends a "get_all_statuses" message to the backend upon WebSocket connection to fetch the statuses of all users.
- The backend now handles the "get_all_statuses" message and returns the current status of all connected users.
- Added logging to the frontend to help with debugging status updates.