### PR TITLE
fix: Configure CORS to allow frontend origin

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -348,10 +348,15 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
 # Include the router in the main app
 app.include_router(api_router)
 
+origins = [
+    "https://showtime-employee-portal.vercel.app",
+    "http://localhost:3000",
+]
+
 app.add_middleware(
     CORSMiddleware,
     allow_credentials=True,
-    allow_origins=["*"], # Adjust for production
+    allow_origins=origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
This commit fixes a CORS issue that prevented the frontend from making API requests to the backend.

The `CORSMiddleware` in `backend/server.py` was configured to allow all origins ("*"). However, when `allow_credentials` is True, browsers do not permit a wildcard origin.

This change replaces the wildcard with a specific list of allowed origins, including the production frontend URL (`https://showtime-employee-portal.vercel.app`) and the standard local development URL (`http://localhost:3000`).